### PR TITLE
Fix access API rejection response

### DIFF
--- a/server/funcs/acess.php
+++ b/server/funcs/acess.php
@@ -63,8 +63,7 @@
         }
       }
       if ($ok == false) {
-        echo '!ok';
-        exit;
+        err401();
       }
     } else {
       if (in_array($func, $acess[$page]) == false) {


### PR DESCRIPTION
## Summary
- handle unauthorized access in `acessApi` by returning 401 JSON instead of plain text

## Testing
- `php -l server/funcs/acess.php`


------
https://chatgpt.com/codex/tasks/task_e_6872cdebddd883299dbb6cb0bf7c030a